### PR TITLE
Signal messenger attachments as bytes support testfix

### DIFF
--- a/homeassistant/components/signal_messenger/notify.py
+++ b/homeassistant/components/signal_messenger/notify.py
@@ -1,8 +1,8 @@
 """Signal Messenger for notify component."""
 import logging
-import requests
 
 from pysignalclirestapi import SignalCliRestApi, SignalCliRestApiError
+import requests
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -52,9 +52,7 @@ class SignalNotificationService(BaseNotificationService):
         self._signal_cli_rest_api = signal_cli_rest_api
 
     def send_message(self, message="", **kwargs):
-        """Send a message to a one or more recipients.
-        Additionally a file can be attached.
-        """
+        """Send a message to a one or more recipients. Additionally a file can be attached."""
 
         _LOGGER.debug("Sending signal message")
 
@@ -74,18 +72,21 @@ class SignalNotificationService(BaseNotificationService):
                     filenames = [data[ATTR_FILENAME]]
                 else:
                     filenames.append(data[ATTR_FILENAME])
-            
             if ATTR_URLS in data:
                 urls = data[ATTR_URLS]
                 for url in urls:
                     try:
-                        attachments_as_bytes.append((requests.get(url, verify=False, timeout=10)).content)
+                        attachments_as_bytes.append(
+                            (requests.get(url, verify=False, timeout=10)).content
+                        )
                     except Exception as ex:
                         _LOGGER.error("%s", ex)
                         raise ex
 
         try:
-            self._signal_cli_rest_api.send_message(message, self._recp_nrs, filenames, attachments_as_bytes)
+            self._signal_cli_rest_api.send_message(
+                message, self._recp_nrs, filenames, attachments_as_bytes
+            )
         except SignalCliRestApiError as ex:
             _LOGGER.error("%s", ex)
             raise ex

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -20,7 +20,7 @@ SIGNAL_SEND_PATH_SUFIX = "/v2/send"
 MESSAGE = "Testing Signal Messenger platform :)"
 NUMBER_FROM = "+43443434343"
 NUMBERS_TO = ["+435565656565"]
-URL_ATTACHMENT = "https://www.home-assistant.io/images/favicon-192x192-full.png"
+URL_ATTACHMENT = "http://127.0.0.1:8080/image.jpg"
 
 
 @pytest.fixture
@@ -36,5 +36,11 @@ def signal_requests_mock(requests_mock):
         "http://127.0.0.1:8080/v1/about",
         status_code=HTTPStatus.OK,
         json={"versions": ["v1", "v2"]},
+    )
+    requests_mock.register_uri(
+        "GET",
+        "http://127.0.0.1:8080/image.jpg",
+        status_code=HTTPStatus.OK,
+        content=None,
     )
     return requests_mock

--- a/tests/components/signal_messenger/test_notify.py
+++ b/tests/components/signal_messenger/test_notify.py
@@ -91,6 +91,7 @@ def send_message_with_attachment(signal_notification_service, deprecated=False):
         data = {"attachment": tf.name} if deprecated else {"attachments": [tf.name]}
         signal_notification_service.send_message(MESSAGE, **{"data": data})
 
+
 def test_send_message_with_attachment_as_url(
     signal_notification_service, signal_requests_mock, caplog
 ):
@@ -102,7 +103,7 @@ def test_send_message_with_attachment_as_url(
 
     assert "Sending signal message" in caplog.text
     assert signal_requests_mock.called
-    assert signal_requests_mock.call_count == 2
+    assert signal_requests_mock.call_count == 3
     assert_sending_requests(signal_requests_mock, 1)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes Signal tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
